### PR TITLE
Altera CI para evitar run duplo do workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,9 @@
 name: Build
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: test-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: Test
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: test-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,9 @@
 name: Test
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Descrição

- Adiciona checkagem para evitar que o CI rode duas vezes no mesmo trigger

## Evidências:
**Agora não roda repetidamente quando abrimos uma pr ou atualizamos a pr**
![image](https://github.com/user-attachments/assets/62f7109a-2d75-4296-82f4-364ee0ce4b5b)

## Tipo de Mudança

- Nova Funcionalidade

## Issues Relacionadas

- Resolve #16 

---
