### PR TITLE
refact: improve keep-alive connection

### DIFF
--- a/src/parsers/Connection.cpp
+++ b/src/parsers/Connection.cpp
@@ -1,5 +1,6 @@
 #include "Connection.hpp"
 #include "header.hpp"
+#include "logger.hpp"
 #include "parser.hpp"
 #include "Request.hpp"
 #include "response.hpp"
@@ -16,7 +17,8 @@ Connection::Connection(int fd, string ip)
 	  _time(time(NULL)),
 	  _startline_parsed(false),
 	  _headers_parsed(false),
-	  _send(false) {
+	  _send(false),
+	  _transfers(0) {
 
 }
 
@@ -47,6 +49,7 @@ Connection &Connection::operator=(const Connection &rhs) {
 	_startline_parsed = rhs._startline_parsed;
 	_headers_parsed = rhs._headers_parsed;
 	_send = rhs._send;
+	_transfers = rhs._transfers;
 
 	return *this;
 }
@@ -80,6 +83,8 @@ void Connection::parseRequest(void) {
 		_code = "200";
 		_status = "Ok";
 	}
+
+	logger::info(_host + " " + _method + " " + _path + " " + _protocol + " " + _code + " - " + _headers["User-Agent"]);
 
 	buildResponse();
 }
@@ -247,6 +252,9 @@ void Connection::buildResponse(void) {
 	if (getHeaderByKey(header::CONNECTION) != "keep-alive")
 		_headers[header::CONNECTION] = "close";
 
+	_transfers++;
+
+	_headers[header::CONTENT_LENGTH] = parser::toString(_body.size());
 	_headers[header::SERVER] = "webserv/0.1.0";
 
 	ostringstream oss;
@@ -256,6 +264,7 @@ void Connection::buildResponse(void) {
 	for (; it != _headers.end(); it++)
 		oss << it->first + ": " + it->second + "\r\n";
 
+	_body.clear();
 	oss << "\r\n" << _body;
 
 	_response = oss.str();
@@ -310,6 +319,11 @@ void Connection::setSend(bool send) {
 bool Connection::getSend(void) const {
 
 	return _send;
+}
+
+size_t Connection::getTransfers(void) const {
+
+	return _transfers;
 }
 
 void Connection::resetConnection(void) {

--- a/src/parsers/Connection.hpp
+++ b/src/parsers/Connection.hpp
@@ -26,6 +26,7 @@ class Connection {
 		bool _startline_parsed;
 		bool _headers_parsed;
 		bool _send;
+		size_t _transfers;
 
 		void parseRequest(void);
 
@@ -71,6 +72,7 @@ class Connection {
 		bool getHeadersParsed(void) const;
 		void setSend(bool send);
 		bool getSend(void) const;
+		size_t getTransfers(void) const;
 		void resetConnection(void);
 
 };

--- a/src/parsers/WebServ.cpp
+++ b/src/parsers/WebServ.cpp
@@ -118,7 +118,7 @@ struct addrinfo *WebServ::getAddrInfo(string host) {
 
 	list<string> tmp = parser::split(host, ':');
 	if (getaddrinfo(tmp.front().c_str(), tmp.back().c_str(), &hints, &res))
-		throw runtime_error("getaddrinfo");
+		throw runtime_error("getaddrinfo failed");
 
 	return res;
 }
@@ -129,14 +129,14 @@ int WebServ::createSocket(string host) {
 
 	int fd = socket(res->ai_family, res->ai_socktype | SOCK_NONBLOCK, res->ai_protocol);
 	if (fd < 0)
-		throw runtime_error("socket");
+		throw runtime_error("socket failed");
 
 	struct linger opt = (struct linger){};
 	opt.l_onoff = 1;
 	opt.l_linger = 10;
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1) {
 		(close(fd), freeaddrinfo(res));
-		throw runtime_error("setsockopt");
+		throw runtime_error("setsockopt failed");
 	}
 
 	if (bind(fd, res->ai_addr, res->ai_addrlen) != 0) {
@@ -148,7 +148,7 @@ int WebServ::createSocket(string host) {
 
 	if (listen(fd, WebServ::MAX_EVENTS) == -1) {
 		close(fd);
-		throw runtime_error("listen");
+		throw runtime_error("listen failed");
 	}
 
 	return fd;
@@ -161,7 +161,7 @@ void WebServ::controlEpoll(int client_fd, int flag, int option) {
 	event.data.fd = client_fd;
 
 	if (epoll_ctl(_epoll_fd, option, client_fd, &event) == -1)
-		logger::fatal("epoll_ctl");
+		logger::fatal("epoll_ctl failed");
 }
 
 string WebServ::getIpByFileDescriptor(int client_fd) {
@@ -170,7 +170,7 @@ string WebServ::getIpByFileDescriptor(int client_fd) {
 	socklen_t addr_len = sizeof(local_addr);
 
 	if (getsockname(client_fd, (sockaddr *) &local_addr, &addr_len) == -1)
-		throw runtime_error("getsockname");
+		throw runtime_error("getsockname failed");
 
 	int ip = htonl(local_addr.sin_addr.s_addr);
 	unsigned short port = htons(local_addr.sin_port);
@@ -190,7 +190,7 @@ void WebServ::acceptNewConnection(int client_fd) {
 	int fd = accept(client_fd, NULL, NULL);
 	if (fd == -1) {
 		if (not (errno == EAGAIN || errno == EWOULDBLOCK))
-			logger::fatal("accept");
+			logger::fatal("accept failed");
 		return;
 	}
 
@@ -237,9 +237,6 @@ void WebServ::handleRequest(int client_fd) {
 	if (connection->getSend() == false)
 		return controlEpoll(client_fd, EPOLLIN | EPOLLET, EPOLL_CTL_MOD);
 
-	logger::info("received: ");
-	cout << connection->getBuffer() << endl;
-	
 	controlEpoll(client_fd, EPOLLOUT | EPOLLET, EPOLL_CTL_MOD);
 }
 
@@ -269,8 +266,6 @@ void WebServ::handleResponse(int client_fd) {
 		return controlEpoll(client_fd, EPOLLIN | EPOLLET, EPOLL_CTL_MOD);
 	}
 
-	cout << *_client_connections.find(client_fd)->second << endl;
-
 	closeConnection(client_fd);
 }
 
@@ -287,13 +282,20 @@ int WebServ::isBindedSocket(int fd) {
 bool WebServ::isTimedOut(int client_fd) {
 
 	map<int, Connection *>::iterator it = _client_connections.find(client_fd);
+	Connection *connection = it->second;
+
 	if (it == _client_connections.end())
 		return false;
 
-	if (time(NULL) - it->second->getTime() <= WebServ::TIMEOUT)
+	if (connection->getTransfers() && time(NULL) - connection->getTime() >= KEEP_ALIVE) {
+		closeConnection(client_fd);
+		return true;
+	}
+
+	if (time(NULL) - connection->getTime() <= WebServ::TIMEOUT)
 		return false;
 
-	response::pageGatewayTimeOut(it->second);
+	response::pageGatewayTimeOut(connection);
 
 	controlEpoll(client_fd, EPOLLOUT | EPOLLET, EPOLL_CTL_MOD);
 
@@ -304,7 +306,7 @@ void WebServ::run(void) {
 
 	_epoll_fd = epoll_create(1);
 	if (_epoll_fd < 0)
-		throw runtime_error("epoll");
+		throw runtime_error("epoll failed");
 
 	map<string, int>::iterator it = _binded_sockets.begin();
 	for (; it != _binded_sockets.end(); it++) {
@@ -317,7 +319,7 @@ void WebServ::run(void) {
 	while (true) {
 		int num_events = epoll_wait(_epoll_fd, events, MAX_EVENTS, 0);
 		if (num_events == -1)
-			throw runtime_error("epoll_wait");
+			throw runtime_error("epoll_wait failed");
 
 		for (int i = 0; i < num_events; i++) {
 			if (isBindedSocket(events[i].data.fd))

--- a/src/parsers/WebServ.hpp
+++ b/src/parsers/WebServ.hpp
@@ -34,6 +34,7 @@ class WebServ {
 		static const int BUFFER_SIZE = parser::MEGABYTE;
 		static const int MAX_EVENTS = 252;
 		static const long TIMEOUT = 30;
+		static const long KEEP_ALIVE = 5;
 		
 		WebServ(Http *http);
 		WebServ(const WebServ &src);


### PR DESCRIPTION
## Descrição

Melhora o desempenho de conexões keep-alive em navegadores.
- Permite que a conexão fique aberta por até 5 segundos até que o navegador pare de enviar requests.

## Tipo de Mudança

- Correção de Bug
- Refatoração

## Issues Relacionadas

- Resolve #47

---
