### PR TITLE
Arruma segfault do Mime

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
 
 		http = new Http(argv[1] ? argv[1] : "configurations/default.conf");
 
-		mimes = new Mime();
+		mimes = new Mime("src/parsers/mimes.json");
 
 		cout << *http << endl;
 

--- a/src/parsers/Mime.cpp
+++ b/src/parsers/Mime.cpp
@@ -1,6 +1,7 @@
 #include "logger.hpp"
 #include "Mime.hpp"
 #include "parser.hpp"
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -10,10 +11,8 @@
 
 using namespace std;
 
-Mime::Mime(void)
+Mime::Mime(string filename)
 	: _default_mime("text/plain") {
-
-	string filename = "./src/parsers/mimes.json";
 
 	try {
 		ifstream file(filename.c_str());

--- a/src/parsers/Mime.hpp
+++ b/src/parsers/Mime.hpp
@@ -13,7 +13,7 @@ class Mime {
 		void parseMimes(std::string &buffer);
 
 	public:
-		Mime(void);
+		Mime(std::string filename);
 		Mime(const Mime &src);
 		Mime &operator=(const Mime &rhs);
 		~Mime(void);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -6,7 +6,7 @@
 #include "Mime.hpp"
 #include <gtest/gtest.h>
 
-Mime *mimes = NULL;
+Mime *mimes;
 Http *http = NULL;
 
 int main(int argc, char **argv) {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -6,7 +6,7 @@
 #include "Mime.hpp"
 #include <gtest/gtest.h>
 
-Mime *mimes;
+Mime *mimes = NULL;
 Http *http = NULL;
 
 int main(int argc, char **argv) {

--- a/tests/request_test.cpp
+++ b/tests/request_test.cpp
@@ -1,11 +1,15 @@
 #include "gtest/gtest.h"
+#include "Mime.hpp"
 #include "Request.hpp"
 #include "Connection.hpp"
 #include "response.hpp"
 
+extern Mime *mimes;
+
 using namespace std;
 
 TEST(RequestTest, ParseRequest_ValidRequest) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);
@@ -15,6 +19,7 @@ TEST(RequestTest, ParseRequest_ValidRequest) {
 }
 
 TEST(RequestTest, ParseRequest_InvalidSpacing) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "        GET    /index.html     HTTP/1.1   ";
 	request::parseRequest(&connection, line);
@@ -25,6 +30,7 @@ TEST(RequestTest, ParseRequest_InvalidSpacing) {
 }
 
 TEST(RequestTest, ParseRequest_InvalidSpacingDuplicate) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "        GET    /index.html     HTTP/1.1   ";
 	request::parseRequest(&connection, line);
@@ -35,6 +41,7 @@ TEST(RequestTest, ParseRequest_InvalidSpacingDuplicate) {
 }
 
 TEST(RequestTest, ParseRequest_MissingPath) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET HTTP/1.1";
 	request::parseRequest(&connection, line);
@@ -45,20 +52,23 @@ TEST(RequestTest, ParseRequest_MissingPath) {
 }
 
 TEST(RequestTest, ParseRequest_InvalidMethod) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "PATCH /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);
-	EXPECT_EQ(connection.getCode(), "400") << "Code should be 400";
+	EXPECT_EQ(connection.getCode(), "405") << "Code should be 405";
 }
 
 TEST(RequestTest, ParseRequest_InvalidMethodDuplicate) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "PATCH /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);
-	EXPECT_EQ(connection.getCode(), "400") << "Code should be 400";
+	EXPECT_EQ(connection.getCode(), "405") << "Code should be 405";
 }
 
 TEST(RequestTest, ParseRequest_InvalidProtocol) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.2";
 	request::parseRequest(&connection, line);
@@ -66,6 +76,7 @@ TEST(RequestTest, ParseRequest_InvalidProtocol) {
 }
 
 TEST(RequestTest, ParseRequest_HeadersParsed) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.1\r";
 	request::parseRequest(&connection, line);
@@ -75,6 +86,7 @@ TEST(RequestTest, ParseRequest_HeadersParsed) {
 }
 
 TEST(RequestTest, ParseRequest_HeadersNotParsed) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);


### PR DESCRIPTION
## Descrição

Arruma a exceção de segfault causada pela abertura errada do arquivo json dos mimes.

## Evidências (se aplicavel)

![image](https://github.com/user-attachments/assets/127859ee-7b18-49d9-96ba-6378fc8e1795)

## Tipo de Mudança

- Correção de Bug
## Issues Relacionadas

- Resolve #62 

---
