### PR TITLE
refact: handle sigint to exit without leaks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,17 +12,16 @@ using namespace std;
 Http *http = NULL;
 Mime *mimes = NULL;
 
-static void sigexit(int signal) {
-
-	delete http;
-	delete mimes;
+static void handle_signal(int signal) {
 	
-	exit(signal);
+	(void) signal;
+
+	http->stop();
 }
 
 int main(int argc, char *argv[]) {
 
-	signal(SIGINT, sigexit);
+	signal(SIGINT, handle_signal);
 
 	int status = EXIT_SUCCESS;
 
@@ -46,5 +45,8 @@ int main(int argc, char *argv[]) {
 		status = EXIT_FAILURE;
 	}
 
-	sigexit(status);
+	delete http;
+	delete mimes;
+
+	return status;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
 
 		http = new Http(argv[1] ? argv[1] : "configurations/default.conf");
 
-		mimes = new Mime();
+		mimes = new Mime("src/parsers/mimes.json");
 
 		cout << *http << endl;
 

--- a/src/parsers/Http.cpp
+++ b/src/parsers/Http.cpp
@@ -9,10 +9,9 @@
 
 using namespace std;
 
-WebServ *webserv;
-
 Http::Http(string filename)
-	: _autoindex(parser::AUTOINDEX_NOT_SET),
+	: _webserv(NULL),
+	  _autoindex(parser::AUTOINDEX_NOT_SET),
 	  _max_body_size(0) {
 
 	if (parser::basename(filename) != ".conf")
@@ -81,7 +80,8 @@ Http &Http::operator=(const Http &rhs) {
 
 Http::~Http(void) {
 
-	delete webserv;
+	if (_webserv)
+		delete _webserv;
 
 }
 
@@ -245,9 +245,14 @@ bool Http::empty(void) const {
 
 void Http::start(void) {
 
-	webserv = new WebServ(this);
+	_webserv = new WebServ(this);
 
-	webserv->run();
+	_webserv->run();
+}
+
+void Http::stop(void) {
+
+	_webserv->stop();
 }
 
 ostream &operator<<(ostream &os, const Http &src) {

--- a/src/parsers/Http.hpp
+++ b/src/parsers/Http.hpp
@@ -2,6 +2,7 @@
 #define HTTP_HPP
 
 #include "Server.hpp"
+#include "WebServ.hpp"
 #include <bitset>
 #include <map>
 #include <ostream>
@@ -11,6 +12,7 @@
 
 class Http {
 	private:
+		WebServ *_webserv;
 		std::string _access_log;
 		std::string _error_log;
 		std::string _root;
@@ -52,6 +54,7 @@ class Http {
 		std::vector<Server> getServers(void) const;
 		bool empty(void) const;
 		void start(void);
+		void stop(void);
 };
 
 std::ostream &operator<<(std::ostream &os, const Http &src);

--- a/src/parsers/Mime.cpp
+++ b/src/parsers/Mime.cpp
@@ -1,6 +1,7 @@
 #include "logger.hpp"
 #include "Mime.hpp"
 #include "parser.hpp"
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -10,10 +11,8 @@
 
 using namespace std;
 
-Mime::Mime(void)
+Mime::Mime(string filename)
 	: _default_mime("text/plain") {
-
-	string filename = "./src/parsers/mimes.json";
 
 	try {
 		ifstream file(filename.c_str());

--- a/src/parsers/Mime.hpp
+++ b/src/parsers/Mime.hpp
@@ -13,7 +13,7 @@ class Mime {
 		void parseMimes(std::string &buffer);
 
 	public:
-		Mime(void);
+		Mime(std::string filename);
 		Mime(const Mime &src);
 		Mime &operator=(const Mime &rhs);
 		~Mime(void);

--- a/src/parsers/WebServ.cpp
+++ b/src/parsers/WebServ.cpp
@@ -18,7 +18,8 @@ using namespace std;
 
 WebServ::WebServ(Http *http)
 	: _http(http),
-	  _epoll_fd(-1) {
+	  _epoll_fd(-1),
+	  _run(true) {
 
 	vector<Server> servers = _http->getServers();
 	for (vector<Server>::iterator it = servers.begin(); it != servers.end(); it++) {
@@ -319,7 +320,7 @@ void WebServ::run(void) {
 
 	epoll_event events[MAX_EVENTS];
 
-	while (true) {
+	while (_run) {
 		int num_events = epoll_wait(_epoll_fd, events, MAX_EVENTS, 0);
 		if (num_events == -1)
 			throw runtime_error("epoll_wait failed");
@@ -337,4 +338,9 @@ void WebServ::run(void) {
 			if (isTimedOut(ite->first))
 				break;
 	}
+}
+
+void WebServ::stop(void) {
+
+	_run = false;
 }

--- a/src/parsers/WebServ.hpp
+++ b/src/parsers/WebServ.hpp
@@ -16,6 +16,7 @@ class WebServ {
 		int _epoll_fd;
 		std::map<std::string, int> _binded_sockets;
 		std::map<int, Connection *> _client_connections;
+		bool _run;
 
 		void removeBindedPorts(std::string port);
 		bool isBinded(std::string listen);
@@ -43,6 +44,7 @@ class WebServ {
 		virtual ~WebServ(void);
 
 		void run(void);
+		void stop(void);
 };
 
 #endif /* WEBSERV_HPP */

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -6,7 +6,7 @@
 #include "Mime.hpp"
 #include <gtest/gtest.h>
 
-Mime *mimes = NULL;
+Mime *mimes;
 Http *http = NULL;
 
 int main(int argc, char **argv) {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -6,7 +6,7 @@
 #include "Mime.hpp"
 #include <gtest/gtest.h>
 
-Mime *mimes;
+Mime *mimes = NULL;
 Http *http = NULL;
 
 int main(int argc, char **argv) {

--- a/tests/request_test.cpp
+++ b/tests/request_test.cpp
@@ -1,11 +1,15 @@
 #include "gtest/gtest.h"
+#include "Mime.hpp"
 #include "Request.hpp"
 #include "Connection.hpp"
 #include "response.hpp"
 
+extern Mime *mimes;
+
 using namespace std;
 
 TEST(RequestTest, ParseRequest_ValidRequest) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);
@@ -15,6 +19,7 @@ TEST(RequestTest, ParseRequest_ValidRequest) {
 }
 
 TEST(RequestTest, ParseRequest_InvalidSpacing) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "        GET    /index.html     HTTP/1.1   ";
 	request::parseRequest(&connection, line);
@@ -25,6 +30,7 @@ TEST(RequestTest, ParseRequest_InvalidSpacing) {
 }
 
 TEST(RequestTest, ParseRequest_InvalidSpacingDuplicate) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "        GET    /index.html     HTTP/1.1   ";
 	request::parseRequest(&connection, line);
@@ -35,6 +41,7 @@ TEST(RequestTest, ParseRequest_InvalidSpacingDuplicate) {
 }
 
 TEST(RequestTest, ParseRequest_MissingPath) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET HTTP/1.1";
 	request::parseRequest(&connection, line);
@@ -45,20 +52,23 @@ TEST(RequestTest, ParseRequest_MissingPath) {
 }
 
 TEST(RequestTest, ParseRequest_InvalidMethod) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "PATCH /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);
-	EXPECT_EQ(connection.getCode(), "400") << "Code should be 400";
+	EXPECT_EQ(connection.getCode(), "405") << "Code should be 405";
 }
 
 TEST(RequestTest, ParseRequest_InvalidMethodDuplicate) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "PATCH /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);
-	EXPECT_EQ(connection.getCode(), "400") << "Code should be 400";
+	EXPECT_EQ(connection.getCode(), "405") << "Code should be 405";
 }
 
 TEST(RequestTest, ParseRequest_InvalidProtocol) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.2";
 	request::parseRequest(&connection, line);
@@ -66,6 +76,7 @@ TEST(RequestTest, ParseRequest_InvalidProtocol) {
 }
 
 TEST(RequestTest, ParseRequest_HeadersParsed) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.1\r";
 	request::parseRequest(&connection, line);
@@ -75,6 +86,7 @@ TEST(RequestTest, ParseRequest_HeadersParsed) {
 }
 
 TEST(RequestTest, ParseRequest_HeadersNotParsed) {
+	mimes = new Mime("../../src/parsers/mimes.json");
 	Connection connection(5, "127.0.0.1");
 	string line = "GET /index.html HTTP/1.1";
 	request::parseRequest(&connection, line);


### PR DESCRIPTION
## Descrição

Arruma o handler da sigint para sair do programa sem leaks mesmo quando no meio da execução de uma função.

## Evidências

![image](https://github.com/user-attachments/assets/698c0883-cc8b-4bd0-81e6-96576663a6e6)

## Tipo de Mudança

- Correção de Bug

## Observação 

Aprovar depois do #65

---
