### PR TITLE
Fix CI trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build
 
 concurrency:
-  group: test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,4 +27,3 @@ jobs:
       - name: Run tests
         run: |
           make test
-### push test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,3 +27,4 @@ jobs:
       - name: Run tests
         run: |
           make test
+### push test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: Test
 
 concurrency:
-  group: test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
- **fix: update concurrency group naming in build workflow**
- **fix: update concurrency group naming in GitHub Actions workflow**
- **chore: add comment for push test in GitHub Actions workflow**
- **test again**

## Descrição

- Ajusta CI para que os testes não fiquem rodando paralelamente.

## Evidências (se aplicavel)

![image](https://github.com/user-attachments/assets/be5eadcd-282d-4c17-9f7d-1d4700e8dd3e)

## Tipo de Mudança

- Correção de Bug

---
