### PR TITLE
89 Implementa tests para header.hpp

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,9 @@ if(BUILD_TESTING)
 			location_test.cpp
 			request_test.cpp
 			connection_test.cpp
-      afile_test.cpp
+			afile_test.cpp
 			mime_test.cpp
+			header_test.cpp
 	)
 
 	target_link_libraries(webreq

--- a/tests/header_test.cpp
+++ b/tests/header_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include "header.hpp"
+
+TEST(HeaderTest, AcceptConstant) {
+	EXPECT_EQ(header::ACCEPT, "Accept");
+}
+
+TEST(HeaderTest, ConnectionConstant) {
+	EXPECT_EQ(header::CONNECTION, "Connection");
+}
+
+TEST(HeaderTest, ContentTypeConstant) {
+	EXPECT_EQ(header::CONTENT_TYPE, "Content-Type");
+}
+
+TEST(HeaderTest, ContentLengthConstant) {
+	EXPECT_EQ(header::CONTENT_LENGTH, "Content-Length");
+}
+
+TEST(HeaderTest, HostConstant) {
+	EXPECT_EQ(header::HOST, "Host");
+}
+
+TEST(HeaderTest, LocationConstant) {
+	EXPECT_EQ(header::LOCATION, "Location");
+}
+
+TEST(HeaderTest, KeepAliveConstant) {
+	EXPECT_EQ(header::KEEP_ALIVE, "Keep-alive");
+}
+
+TEST(HeaderTest, RefererConstant) {
+	EXPECT_EQ(header::REFERER, "Referer");
+}
+
+TEST(HeaderTest, ServerConstant) {
+	EXPECT_EQ(header::SERVER, "Server");
+}
+
+TEST(HeaderTest, UserAgentConstant) {
+	EXPECT_EQ(header::USER_AGENT, "User-Agent");
+}
+
+TEST(HeaderTest, TransferEncondingConstant) {
+	EXPECT_EQ(header::TRANSFER_ENCONDING, "Transfer-Encoding");
+}


### PR DESCRIPTION
## Descrição

- Adiciona testes para header.hpp

## Evidências (se aplicavel)
![image](https://github.com/user-attachments/assets/9084d18a-470d-4f6f-bbc1-7821b06b416e)

## Tipo de Mudança
- Testes

## Issues Relacionadas

- Resolve #89 

---
