### PR TITLE
Feature/301-move

### DIFF
--- a/configurations/php-test.conf
+++ b/configurations/php-test.conf
@@ -1,7 +1,7 @@
 server {
     listen 8090;
     server_name mypage.com;
-    root ./var/www/html/mysite;
+    root ./var/www/html;
     index index.htm index.html index.php;
 
     location / {

--- a/src/files/AutoIndex.cpp
+++ b/src/files/AutoIndex.cpp
@@ -74,8 +74,7 @@ void AutoIndex::generateContent(void) {
 
 	typedef std::vector<std::string>::iterator vector_iterator;
 	for (vector_iterator it = entries.begin(); it != entries.end(); ++it) {
-		response += "<a href=\"" 
-			+ partPath + *it + "\" class=\"text-blue-500 hover:underline text-lg block\">" 
+		response += "<a href=\"./" + *it + "\" class=\"text-blue-500 hover:underline text-lg block\">" 
 			+ *it 
 			+ "</a>\n";
 	}

--- a/src/parsers/Connection.cpp
+++ b/src/parsers/Connection.cpp
@@ -315,7 +315,7 @@ void Connection::buildResponse(void) {
 		_headers[header::CONTENT_TYPE] = _file->getMime();
 	}
 	_headers[header::SERVER] = "webserv/0.1.0";
-
+	logger::info(_host + " " + _method + " " + _path + " " + _protocol + " " + _code + " - " + getHeaderByKey(header::USER_AGENT));
 	ostringstream oss;
 	oss <<  _protocol + " " + _code + " " + _status + "\r\n";
 

--- a/src/response/process.cpp
+++ b/src/response/process.cpp
@@ -14,46 +14,51 @@
 using namespace std;
 
 void process::request(Connection *connection) {
+    string url = (*connection)[header::REFERER];
+    // if (url.size()) #FIXME: this condition is duplicating the path in some cases (e.g. links in html) 
+    //  connection->setPath(process::getPathFromReferer(url) + connection->getPath());
 
-	string url = (*connection)[header::REFERER];
-	// if (url.size()) #FIXME: this condition is duplicating the path in some cases (e.g. links in html) 
-	// 	connection->setPath(process::getPathFromReferer(url) + connection->getPath());
+    Location location = process::isValidPath(connection);
+    connection->setLocation(location);
+	cout << "getPath::::" << connection->getPath() << endl;
+    cout << location << endl;
+    if (location.empty())
+        return response::pageNotFound(connection);
+    if (location.getReturnCode().size())
+        // TODO: check return code to call the correct response page
+        return response::pageMovedPermanently(connection);
 
-	Location location = process::isValidPath(connection);
-	connection->setLocation(location);
-	cout << location << endl;
-	if (location.empty())
-		return response::pageNotFound(connection);
-	else if (location.getReturnCode().size())
-		// TODO: check return code to call the correct response page
-		return response::pageMovedPermanently(connection);
+    string queryString = connection->getPath().find('?') != string::npos ? connection->getPath().substr(connection->getPath().find('?')) : "";
+    if (not queryString.empty())
+        connection->setQueryString(queryString);
 
-	string queryString = connection->getPath().find('?') != string::npos ? connection->getPath().substr(connection->getPath().find('?')) : "";
-	if (not queryString.empty())
-		connection->setQueryString(queryString);
-
-
-	string path = connection->getPath();
-	path = not queryString.empty() ? path.substr(0, path.find('?')) : path;
+    string path = connection->getPath();
+    path = not queryString.empty() ? path.substr(0, path.find('?')) : path;
 
 	string uri = path;
 	path = location.getRoot() + connection->getPath();
 
-	connection->setPath(path);
-	if (process::isDirectory(path) && not process::checkIndex(location, connection))
-		return response::pageForbbiden(connection);
+	cout << "PATH:::: " << path << endl;
+    if (process::isDirectory(path) && path[path.size() - 1] != '/') {
+        return response::pageMovedPermanently(connection);
+    }
 
-	cout << path << " " << process::getFileExtension(connection->getPath()) << endl;
 
-	if (process::isCGI(path))
-	{
-		// cout << "CGI Path:::::: " << path << endl;
-		// function to handle CGI
-	}
+    connection->setPath(path);
+    if (process::isDirectory(path) && not process::checkIndex(location, connection))
+        return response::pageForbbiden(connection);
 
-	if (process::isDirectory(connection->getPath()) && location.getAutoIndex())
-		return connection->setFile(new AutoIndex(path, uri));
-	connection->setFile(new File(connection->getPath()));
+    cout << path << " " << process::getFileExtension(connection->getPath()) << endl;
+
+    if (process::isCGI(path))
+    {
+        // cout << "CGI Path:::::: " << path << endl;
+        // function to handle CGI
+    }
+
+    if (process::isDirectory(connection->getPath()) && location.getAutoIndex())
+        return connection->setFile(new AutoIndex(path, uri));
+    connection->setFile(new File(connection->getPath()));
 }
 
 bool process::isDirectory(const std::string &path) {

--- a/src/response/process.cpp
+++ b/src/response/process.cpp
@@ -20,13 +20,12 @@ void process::request(Connection *connection) {
 
     Location location = process::isValidPath(connection);
     connection->setLocation(location);
-	cout << "getPath::::" << connection->getPath() << endl;
-    cout << location << endl;
     if (location.empty())
         return response::pageNotFound(connection);
     if (location.getReturnCode().size())
-        // TODO: check return code to call the correct response page
+	{
         return response::pageMovedPermanently(connection);
+	}
 
     string queryString = connection->getPath().find('?') != string::npos ? connection->getPath().substr(connection->getPath().find('?')) : "";
     if (not queryString.empty())
@@ -38,27 +37,26 @@ void process::request(Connection *connection) {
 	string uri = path;
 	path = location.getRoot() + connection->getPath();
 
-	cout << "PATH:::: " << path << endl;
+	
     if (process::isDirectory(path) && path[path.size() - 1] != '/') {
+
+        connection->addHeader(header::LOCATION, connection->getPath() + string("/"));
         return response::pageMovedPermanently(connection);
     }
 
 
-    connection->setPath(path);
-    if (process::isDirectory(path) && not process::checkIndex(location, connection))
+    // connection->setPath(path);
+    if (process::isDirectory(path) && not process::checkIndex(location, path))
         return response::pageForbbiden(connection);
-
-    cout << path << " " << process::getFileExtension(connection->getPath()) << endl;
 
     if (process::isCGI(path))
     {
         // cout << "CGI Path:::::: " << path << endl;
         // function to handle CGI
     }
-
-    if (process::isDirectory(connection->getPath()) && location.getAutoIndex())
+    if (process::isDirectory(path) && location.getAutoIndex())
         return connection->setFile(new AutoIndex(path, uri));
-    connection->setFile(new File(connection->getPath()));
+    connection->setFile(new File(path));
 }
 
 bool process::isDirectory(const std::string &path) {
@@ -157,22 +155,18 @@ Location process::isValidPath(Connection *connection) {
 		if (!location.empty())
 			locations.push_back(location);
 	}
-
-	cout << "location: " << tmp << endl;
-
 	return locations.back();
 }
 
-bool process::checkIndex(const Location &location, Connection *connection) {
+bool process::checkIndex(const Location &location, std::string &path) {
 	const std::set<std::string> &indexes = location.getIndexes();
-	const string &path = connection->getPath();
 	const string &bar = path.find_last_of('/') == path.size() - 1 ? "" : "/";
 
 	typedef std::set<std::string>::const_iterator set_iterator;
 	for (set_iterator it = indexes.begin(); it != indexes.end(); ++it) {
         std::string indexPath = path + bar + *it;
         if (isFile(indexPath)) {
-            connection->setPath(indexPath);
+            path = indexPath;
             return true;
         }
     }

--- a/src/response/process.hpp
+++ b/src/response/process.hpp
@@ -13,7 +13,7 @@ namespace process {
 	bool isFile(const std::string &path);
 	bool isDirectory(const std::string &path);
 	bool isCGI(const std::string &path);
-	bool checkIndex(const Location &location, Connection *connection);
+	bool checkIndex(const Location &location, std::string &path);
 	std::string getFileExtension(std::string path);
 	Location isValidPath(Connection *connection);
 	std::string getPathFromReferer(std::string url);

--- a/src/response/response.cpp
+++ b/src/response/response.cpp
@@ -50,12 +50,10 @@ void response::pageOK(Connection *connection) {
 }
 
 void response::pageMovedPermanently(Connection *connection) {
-
-	connection->setCode(code::MOVED_PERMANENTLY);
-	connection->setStatus(status::MOVED_PERMANENTLY);
-	// TODO: check if getReturnURI is a valid path or a text
-	//connection->addHeader(header::LOCATION, location.getReturnURI());
-	//connection->setFile(new Text(connection->getLocation().getReturnURI()));
+    connection->setCode(code::MOVED_PERMANENTLY);
+    connection->setStatus(status::MOVED_PERMANENTLY);
+	connection->setFile(new Page(code::MOVED_PERMANENTLY, status::MOVED_PERMANENTLY));
+	connection->addHeader(header::LOCATION, connection->getPath() + string("/"));
 	buildHeaderAndBody(connection);
 }
 

--- a/src/response/response.cpp
+++ b/src/response/response.cpp
@@ -50,10 +50,13 @@ void response::pageOK(Connection *connection) {
 }
 
 void response::pageMovedPermanently(Connection *connection) {
-    connection->setCode(code::MOVED_PERMANENTLY);
-    connection->setStatus(status::MOVED_PERMANENTLY);
-	connection->setFile(new Page(code::MOVED_PERMANENTLY, status::MOVED_PERMANENTLY));
+
+	connection->setCode(code::MOVED_PERMANENTLY);
+	connection->setStatus(status::MOVED_PERMANENTLY);
+	// TODO: check if getReturnURI is a valid path or a text
 	connection->addHeader(header::LOCATION, connection->getPath() + string("/"));
+	connection->setFile(new Page(code::MOVED_PERMANENTLY, status::MOVED_PERMANENTLY));
+	//connection->setFile(new Text(connection->getLocation().getReturnURI()));
 	buildHeaderAndBody(connection);
 }
 


### PR DESCRIPTION
## Descrição

Implementado 301 - Moved Permanently, a qual resolve o comportamento do navegador para redirecionamento quando é pasta sem "/", para o caminho com "/", corrigindo de bug envolvendo os links nesse caso. 
O navegador somente considera o "./" de um link quando a URI possui / no final. 
Refatorado o pageOk para que a variável path não altere o path da Connection, sendo para uso com finalidade de validações e abertura de arquivo.

## Evidências (se aplicavel)

![image](https://github.com/user-attachments/assets/71f70fe3-fcf4-4f6c-87eb-74ae965c8f01)

![image](https://github.com/user-attachments/assets/0fd58a23-324e-4803-a26c-905fc4108357)



## Tipo de Mudança

- Nova Funcionalidadee
- Correção de Bug
- Refatoração

## Issues Relacionadas

- Resolve #94 
---
