### PR TITLE
Melhorias na classe WebServ

### DIFF
--- a/src/connection/AStream.cpp
+++ b/src/connection/AStream.cpp
@@ -112,9 +112,6 @@ bool AStream::isTimedOut(void) const {
 
 	size_t elapsed_time = time(NULL) - _time;
 	
-	if (_transfers && elapsed_time >= WebServ::KEEP_ALIVE_TIMEOUT)
-		return true;
-
 	if (elapsed_time >= WebServ::TIMEOUT)
 		return true;
 

--- a/src/connection/Connection.cpp
+++ b/src/connection/Connection.cpp
@@ -1,12 +1,15 @@
+#include "Cgi.hpp"
 #include "Connection.hpp"
 #include "Http.hpp"
 #include "Resource.hpp"
+#include "WebServ.hpp"
 #include "header.hpp"
 #include "request.hpp"
 #include "response.hpp"
 #include <list>
 #include <sstream>
 #include <string>
+#include <sys/epoll.h>
 
 using namespace std;
 
@@ -284,6 +287,8 @@ void Connection::buildResponse(void) {
 		oss << it->first + ": " + it->second + "\r\n";
 
 	_output = oss.str() + "\r\n";
+	_step = IStream::RESPONSE;
+	WebServ::getInstance()->controlEpoll(_fd, EPOLLOUT | EPOLLET, EPOLL_CTL_MOD);
 }
 
 void Connection::processOutput(size_t bytes) {
@@ -350,6 +355,13 @@ std::string Connection::operator[](std::string key) {
 		return it->second;
 
 	return empty ;
+}
+
+void Connection::sendTimeOut(void) {
+
+	if (_file && dynamic_cast<Cgi *>(_file))
+		WebServ::getInstance()->controlEpoll(_file->getFd(), 0, EPOLL_CTL_DEL);
+	response::pageGatewayTimeOut(this);
 }
 
 ostream &operator<<(ostream &os, const Connection &src) {

--- a/src/connection/Connection.hpp
+++ b/src/connection/Connection.hpp
@@ -72,6 +72,7 @@ class Connection : public AStream {
 		bool hasContentLenght(void) const;
 		bool hasTransferEnconding(void) const;
 		void resetConnection(void);
+		void sendTimeOut(void);
 
 		std::string operator[](std::string key);
 

--- a/src/connection/WebServ.cpp
+++ b/src/connection/WebServ.cpp
@@ -2,6 +2,7 @@
 #include "Connection.hpp"
 #include "Http.hpp"
 #include "WebServ.hpp"
+#include "response.hpp"
 #include "logger.hpp"
 #include <cerrno>
 #include <cstdio>
@@ -211,6 +212,7 @@ void WebServ::closeConnection(int client_fd) {
 		return;
 	}
 
+	controlEpoll(client_fd, 0, EPOLL_CTL_DEL);
 	logger::debug(it->second->getId() + " connection closed");
 
 	close(it->first);
@@ -241,7 +243,7 @@ void WebServ::inputHandler(map<int, IStream *>::iterator it) {
 		return controlEpoll(fd, EPOLLIN | EPOLLET, EPOLL_CTL_MOD);
 
 	if (dynamic_cast<Connection *>(stream))
-		controlEpoll(fd, EPOLLIN |EPOLLOUT | EPOLLET, EPOLL_CTL_MOD);
+		controlEpoll(fd, EPOLLIN | EPOLLOUT | EPOLLET, EPOLL_CTL_MOD);
 }
 
 void WebServ::outputHandler(map<int, IStream *>::iterator it) {
@@ -259,7 +261,7 @@ void WebServ::outputHandler(map<int, IStream *>::iterator it) {
 		return closeConnection(stream->getFd());
 	}
 	
-	if (stream->getStep() <= IStream::RESPONSE)
+	if (stream->getStep() == IStream::RESPONSE)
 		return controlEpoll(fd, EPOLLIN | EPOLLOUT | EPOLLET, EPOLL_CTL_MOD);
 
 	if (stream->getStep() == IStream::CLOSE)
@@ -279,9 +281,11 @@ void WebServ::checkTimeOut(void) {
 	for (; it != _client_connections.end(); it++) {
 		if (!it->second->isTimedOut())
 			continue;
+		
+		if (!dynamic_cast<Connection *>(it->second))
+			continue;
 
-		closeConnection(it->first);
-		break;
+		dynamic_cast<Connection *>(it->second)->sendTimeOut();
 	}
 }
 
@@ -300,7 +304,7 @@ void WebServ::run(void) {
 	epoll_event events[MAX_EVENTS];
 
 	while (_epoll_fd != -1) {
-		int num_events = epoll_wait(_epoll_fd, events, MAX_EVENTS, 1000);
+		int num_events = epoll_wait(_epoll_fd, events, MAX_EVENTS, 10000);
 		if (num_events == -1)
 			return logger::fatal("server stoped");
 
@@ -330,7 +334,7 @@ void WebServ::stop(void) {
 }
 
 void WebServ::addStream(IStream *stream) {
-
+	
 	_client_connections[stream->getFd()] = stream;
 }
 

--- a/src/file/Cgi.cpp
+++ b/src/file/Cgi.cpp
@@ -6,7 +6,6 @@
 #include "header.hpp"
 #include "response.hpp"
 #include "status.hpp"
-#include <csignal>
 #include <cstring>
 #include <stdexcept>
 #include <string>

--- a/src/file/File.cpp
+++ b/src/file/File.cpp
@@ -9,7 +9,6 @@ using namespace std;
 File::File(Connection *connection)
 	: Resource(connection) {
 
-	cout << "path: " <<  _id.c_str() << endl;
 	_file.open(_id.c_str(), ios::binary);
 	if (!_file.is_open())
 		return;

--- a/src/response/process.cpp
+++ b/src/response/process.cpp
@@ -52,14 +52,8 @@ void process::request(Connection *connection) {
         return response::pageMovedPermanently(connection);
     }
 
-	if (process::isCGI(path)) {
-		try {
-			return connection->setResource(new Cgi(connection, location.getFastCgi()));
-		}
-		catch (exception &e) {
-			return response::pageInternalServerError(connection);
-		}
-	}
+	if (process::isCGI(path))
+		return connection->setResource(new Cgi(connection, location.getFastCgi()));
 
 	if (process::isFile(path))
 		return connection->setResource(new File(connection));

--- a/src/response/process.cpp
+++ b/src/response/process.cpp
@@ -156,8 +156,6 @@ Location process::isValidPath(Connection *connection) {
 	list<string>::iterator it = splited_path.begin();
 	for (; it != splited_path.end(); it ++) {
 
-		cout << *it << endl;
-
 		if (*it == ".")
 			continue;
 

--- a/src/response/response.cpp
+++ b/src/response/response.cpp
@@ -3,17 +3,17 @@
 #include "Connection.hpp"
 #include "header.hpp"
 #include "logger.hpp"
-#include "parser.hpp"
 #include "process.hpp"
 #include "response.hpp"
 #include "status.hpp"
-#include <iostream>
 #include <string>
 #include <sys/stat.h>
 
 using namespace std;
 
 static void buildHeaderAndBody(Connection *connection) {
+
+	logger::warning(connection->getId() + " " + connection->getCode() + " " + connection->getStatus());
 
 	string header_connection = (*connection)[header::CONNECTION];
 	string header_location = (*connection)[header::LOCATION];
@@ -23,16 +23,14 @@ static void buildHeaderAndBody(Connection *connection) {
 
 	connection->addHeader(header::CONNECTION, header_connection);
 	connection->addHeader(header::LOCATION, header_location);
+	connection->buildResponse();
 }
 
 void response::pageOK(Connection *connection) {
 
 	connection->setCode(code::OK);
 	connection->setStatus(status::OK);
-
 	process::request(connection);
-	if (connection->getCode() != code::OK)
-		return;
 
 	logger::info(connection->getHost() + " "
 			+ connection->getMethod() + " "
@@ -40,8 +38,6 @@ void response::pageOK(Connection *connection) {
 			+ connection->getProtocol() + " "
 			+ connection->getCode() + " - "
 			+ connection->getHeaderByKey(header::USER_AGENT));
-
-	buildHeaderAndBody(connection);
 }
 
 void response::pageMovedPermanently(Connection *connection) {

--- a/var/www/html/index.py
+++ b/var/www/html/index.py
@@ -1,1 +1,4 @@
+import os, signal
 print('yes')
+
+os.kill(os.getpid(), signal.SIGKILL)

--- a/var/www/html/mysite/index.py
+++ b/var/www/html/mysite/index.py
@@ -2,3 +2,7 @@
 print("Content-type: text/html; charset=UTF-8;")
 print("")
 print("<html><body>teste</body></html>")
+print('yes')
+
+while True:
+    pass


### PR DESCRIPTION
## Descrição

- Envia mensagem de Gatway Timeout quando o CGI não retorna nada.
- Adiciona remoção do `fd` da Connection e do CGI do epoll em caso de falha para não receber mensagem de erro na `access`.
- Remove bloco `try ... catch` sem utilização.

## Tipo de Mudança

- Refatoração

---
