### PR TITLE
Feature/return error pages

### DIFF
--- a/src/connection/WebServ.cpp
+++ b/src/connection/WebServ.cpp
@@ -286,7 +286,7 @@ void WebServ::checkTimeOut(void) {
 			continue;
 
 		if (connection->isTimedOut())
-			connection->sendTimeOut();
+			return connection->sendTimeOut();
 
 		if (!connection->isKeepAliveTimedOut())
 			continue;

--- a/src/file/Cgi.cpp
+++ b/src/file/Cgi.cpp
@@ -37,7 +37,6 @@ Cgi::Cgi(Connection *connection)
 
 	URL *uri = _connection->getUri();
 
-	cout << "enter cgi: " << uri->getAbsolutePath() << endl;
 	vector<string> _env;
 	_env.push_back("SERVER_SOFTWARE=webserv/0.1.0");
 	_env.push_back("SERVER_NAME=");

--- a/src/file/Cgi.cpp
+++ b/src/file/Cgi.cpp
@@ -37,6 +37,7 @@ Cgi::Cgi(Connection *connection)
 
 	URL *uri = _connection->getUri();
 
+	cout << "enter cgi: " << uri->getAbsolutePath() << endl;
 	vector<string> _env;
 	_env.push_back("SERVER_SOFTWARE=webserv/0.1.0");
 	_env.push_back("SERVER_NAME=");
@@ -55,7 +56,8 @@ Cgi::Cgi(Connection *connection)
 	_env.push_back("REMOTE_USER=");
 	_env.push_back("REMOTE_IDENT=");
 	_env.push_back("CONTENT_TYPE=" + (*connection)[header::CONTENT_TYPE]);
-	_env.push_back("CONTENT_LENGTH=" + (*connection)[header::CONTENT_LENGTH]);
+	if (*connection == header::CONTENT_LENGTH)
+		_env.push_back("CONTENT_LENGTH=" + (*connection)[header::CONTENT_LENGTH]);
 	_env.push_back("HTTP_COOKIE=" + (*connection)[header::COOKIE]);
 	_env.push_back("REDIRECT_STATUS=200");
 	_env.push_back("HTTP_ACCEPT=" + (*connection)[header::ACCEPT]);
@@ -185,8 +187,6 @@ void Cgi::parse(void) {
 
 void Cgi::sendCGI(void) {
 
-	waitpid(_pid, NULL, WUNTRACED);
-
 	if (_output.find_first_of("\r\n\r\n") == string::npos)
 		return response::pageInternalServerError(_connection);
 
@@ -216,4 +216,7 @@ void Cgi::processInput(size_t bytes) {
 
 	_output.append(_input);
 	_input.erase();
+
+	if (waitpid(_pid, NULL, WNOHANG))
+		sendCGI();
 }

--- a/src/response/response.cpp
+++ b/src/response/response.cpp
@@ -1,19 +1,21 @@
 #include <Connection.hpp>
 #include <IStream.hpp>
 #include <Page.hpp>
+#include "File.hpp"
+#include "URL.hpp"
 #include "code.hpp"
 #include "header.hpp"
 #include "logger.hpp"
 #include "process.hpp"
 #include "response.hpp"
 #include "status.hpp"
-#include <iostream>
 #include <map>
 #include <string>
 
 using namespace std;
 
 static void buildHeaderAndBody(Connection *connection) {
+
 	connection->setStep(IStream::BODY);
 
 	if (connection->getCode() == code::OK) {
@@ -39,6 +41,26 @@ static void buildHeaderAndBody(Connection *connection) {
 	connection->addHeader(header::LOCATION, header_location);
 	connection->setTime();
 	connection->buildResponse();
+}
+
+static bool checkErrorPages(Connection *connection) {
+
+	string page = connection->getLocation().getErrorPageByCode(connection->getCode());
+	if (page == "")
+		return false;
+	
+	string path = connection->getPath();
+
+	connection->setPath(page);
+	URL *uri = new URL(connection);
+
+	connection->setPath(path);
+
+	if (!uri->isFile())
+		return false;
+	
+	connection->setUri(uri);
+	return true;
 }
 
 void response::builder(Connection *connection, string code) {
@@ -75,6 +97,8 @@ void response::builder(Connection *connection, string code) {
 	connection->setStatus(it->second);
 	if (code == code::OK)
 		process::request(connection);
+	else if (checkErrorPages(connection))
+		connection->setResource(new File(connection));
 	else
 		connection->setResource(new Page(connection));
 	if (code == connection->getCode())


### PR DESCRIPTION
## Descrição

- Adiciona retorno da página correspondente informada no arquivo de configuração
- Arruma pequeno erro de Gateway Timeout que não respondia por fechar a conexão
- Arruma POST do cgi informando o Content-Length somente se for enviar um body
- Adiciona o waitpid para a função de processamento de dados para não travar a conexão quando o cgi não enviar o nulo

## Tipo de Mudança

- Nova Funcionalidade

## Issues Relacionadas

- Resolve #113

---
