### PR TITLE
Adiciona URL decoder no target e header value

### DIFF
--- a/src/parser/request.cpp
+++ b/src/parser/request.cpp
@@ -48,6 +48,8 @@ void request::parseStartLine(Connection *connection, string &line) {
 	if (!directive::validateHttpMethod(method))
 		return response::pageMethodNotAllowed(connection);
 
+	URL::decode(target);
+
 	if (target.size() > 2 * parser::KILOBYTE)
 		return response::pageURITooLong(connection);
 
@@ -100,6 +102,9 @@ void request::parseHeaders(Connection *connection, std::string &line) {
 	string value = line.substr(separator + 1);
 
 	URL::decode(value);
+
+	if (value.size() > 8 * parser::KILOBYTE)
+		return response::builder(connection, code::BAD_REQUEST);
 
 	parser::trim(value, " \t\v\r");
 

--- a/src/parser/request.cpp
+++ b/src/parser/request.cpp
@@ -99,13 +99,13 @@ void request::parseHeaders(Connection *connection, std::string &line) {
 	string key = line.substr(0, separator);
 	string value = line.substr(separator + 1);
 
+	URL::decode(value);
+
 	parser::trim(value, " \t\v\r");
 
 	validateHeader(connection, key, value);
 
 	connection->addHeader(key, value);
-
-	return;
 }
 
 void request::parseBody(Connection *connection, string &line) {

--- a/src/parser/request.cpp
+++ b/src/parser/request.cpp
@@ -48,13 +48,13 @@ void request::parseStartLine(Connection *connection, string &line) {
 	if (!directive::validateHttpMethod(method))
 		return response::pageMethodNotAllowed(connection);
 
+	if (!directive::isValidRequestTarget(target))
+		return response::pageBadRequest(connection);
+
 	URL::decode(target);
 
 	if (target.size() > 2 * parser::KILOBYTE)
 		return response::pageURITooLong(connection);
-
-	if (!directive::isValidRequestTarget(target))
-		return response::pageBadRequest(connection);
 
 	if (protocol != response::PROTOCOL)
 		return response::pageHttpVersionNotSupported(connection);

--- a/src/response/URL.cpp
+++ b/src/response/URL.cpp
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
@@ -95,35 +96,6 @@ string URL::checkIndex(const Location &location, string &path) {
 	return "";
 }
 
-void URL::convertCharacters(string &path) {
-
-	std::string output;
-
-	for (size_t i = 0; i < path.length(); ++i) {
-
-		if (path[i] == '%' && i + 2 < path.length()) {
-
-			string tmp = path.substr(i, i + 2);
-
-			if (tmp.find_first_of("0123456789ABCDEFG") != string::npos) {
-				output += '%';
-				continue;
-			}
-
-			std::istringstream iss(tmp);
-			int value;
-
-			iss >> std::hex >> value;
-			output += static_cast<char>(value);
-
-			i += 2;
-		}
-
-		output += path[i];
-	}
-	path = output;
-}
-
 void URL::formatPath(std::string path) {
 
 	list<string> new_path;
@@ -142,7 +114,7 @@ void URL::formatPath(std::string path) {
 			continue;
 		}
 
-		convertCharacters(*it);
+		decode(*it);
 
 		new_path.push_back(*it);
 	}
@@ -372,6 +344,38 @@ bool URL::isExecutable(void) const {
 bool URL::isDeletable() const {
 
 	return _dac & DELETE;
+}
+
+void URL::decode(std::string &path) {
+
+    std::string output;
+
+    for (size_t i = 0; i < path.length(); i++) {
+
+		if (path.at(i) != '%' || path.length() < i + 2) {
+
+			output += path.at(i);
+			continue;
+		}
+
+		string tmp = path.substr(i + 1, 2);
+
+		if (tmp.find_first_not_of("0123456789ABCDEFabcdef") != string::npos) {
+			
+			output += '%';
+			continue;
+		}
+
+		istringstream iss(tmp);
+		int value;
+
+		iss >> hex >> value;
+		output += static_cast<char>(value);
+
+		i += 2;
+	}
+
+    path = output;
 }
 
 ostream &operator<<(ostream &os, const URL &src) {

--- a/src/response/URL.cpp
+++ b/src/response/URL.cpp
@@ -114,8 +114,6 @@ void URL::formatPath(std::string path) {
 			continue;
 		}
 
-		decode(*it);
-
 		new_path.push_back(*it);
 	}
 

--- a/src/response/URL.hpp
+++ b/src/response/URL.hpp
@@ -32,7 +32,6 @@ class URL {
 
 		std::string checkIndex(const Location &location, std::string &path);
 
-		void convertCharacters(std::string &path);
 		void formatPath(std::string path);
 		void processPath(std::string path);
 
@@ -72,6 +71,8 @@ class URL {
 		bool isWritable(void) const;
 		bool isExecutable(void) const;
 		bool isDeletable(void) const;
+
+		static void decode(std::string &path);
 
 };
 


### PR DESCRIPTION
## Descrição

- Adiciona o URL decoder antes de verificar o tamanho do target
- Adiciona o URL decoder antes de verificar o tamanho do header value
- Adiciona limite ao tamanho de header value
- Resolve o bug de `Connection: %20keep-alive%20` que não funcionava

## Tipo de Mudança

- Nova Funcionalidade
- Refatoração

## Issues Relacionadas

- Resolve #149

---
